### PR TITLE
Upload labels to all org repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ OPTIONS
     -H, --host [HOST]
         Specify host. If not specified uses values in config, else ignores config.
 
+    -b, --bulk-update
+        Update all repositories under GHE owner organization. Can only be used with a GitHub Enterprise host.
+
     -f, --force
         Ignore user confirmation.
 
@@ -96,6 +99,9 @@ EXAMPLES
 
     Using GitHub Enterprise hosts:
         labeler -dur Labeler -H github.yourhost.com
+
+    Update all labels from a GHE organization:
+        labeler -b -H github.yourhost.com
 ```
 
 I've tried my best to create a tool for everyone! If you prefer using flags, feel free to run `labeler -t [TOKEN] -o [OWNER] -r [REPOSITORY] -du`. If you fancy writing less, run `labeler -c` and save your values. Those will be your default ones (unless specified by a flag).

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ EXAMPLES
     Using GitHub Enterprise hosts:
         labeler -dur Labeler -H github.yourhost.com
 
-    Update all labels from a GHE organization:
-        labeler -b -H github.yourhost.com
+    Delete and upload all labels from a GHE organization:
+        labeler -dub -H github.yourhost.com
 ```
 
 I've tried my best to create a tool for everyone! If you prefer using flags, feel free to run `labeler -t [TOKEN] -o [OWNER] -r [REPOSITORY] -du`. If you fancy writing less, run `labeler -c` and save your values. Those will be your default ones (unless specified by a flag).

--- a/labeler.js
+++ b/labeler.js
@@ -182,7 +182,7 @@ async function main() {
     // Currently only handles GHE instances, but could probably be adapted for a GitHub user
     if (cli.flags.bulkUpdate) {
         const repos = await helper.getRepositories(token, owner, host)
-        for (repo of repos) {
+        for (const repo of repos) {
             if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repo, cli, false) // Delete all labels from repository
             if (cli.flags.uploadLabels) await helper.uploadLabels(token, owner, host, repo, cli, false) // Upload custom labels to repository
         }

--- a/labeler.js
+++ b/labeler.js
@@ -176,6 +176,8 @@ async function main() {
     if (cli.flags.resetLabelsFile) await helper.resetLabelsFile(cli) // Reset labels.json file
     if (cli.flags.emptyLabelsFile) await helper.emptyLabelsFile(cli) // Delete all labels from labels.json
 
+    // This will delete and/or upload all labels to every repository under the owner organization in GHE
+    // Currently only handles GHE instances, but could probably be adapted for a GitHub user
     if (cli.flags.bulkUpdate) {
         let exit = false;
         let repos = await helper.getRepositories(token, owner, host, cli)
@@ -184,10 +186,6 @@ async function main() {
             if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repos[i], cli, exit) // Delete all labels from repository
             if (cli.flags.uploadLabels) await helper.uploadLabels(token, owner, host, repos[i], cli, exit) // Upload custom labels to repository
         }
-        // await Promise.all(repos.map(async (repo) => {
-        //     if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repo, cli, false) // Delete all labels from repository
-        //     if (cli.flags.uploadLabels) await helper.uploadLabels(token, owner, host, repo, cli, false) // Upload custom labels to repository
-        // }))
     }
     else {
         if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repository, cli, true) // Delete all labels from repository

--- a/labeler.js
+++ b/labeler.js
@@ -178,13 +178,12 @@ async function main() {
     // This will delete and/or upload all labels to every repository under the owner organization in GHE
     // Currently only handles GHE instances, but could probably be adapted for a GitHub user
     if (cli.flags.bulkUpdate) {
-        let exit = false
         const repos = await helper.getRepositories(token, owner, host)
         for (let i=0; i<repos.length; i++) {
-            if (i === repos.length - 1) exit = true
-            if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repos[i], cli, exit) // Delete all labels from repository
-            if (cli.flags.uploadLabels) await helper.uploadLabels(token, owner, host, repos[i], cli, exit) // Upload custom labels to repository
+            if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repos[i], cli, false) // Delete all labels from repository
+            if (cli.flags.uploadLabels) await helper.uploadLabels(token, owner, host, repos[i], cli, false) // Upload custom labels to repository
         }
+        echo.success('Finished!', true)
     }
     else {
         if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repository, cli, true) // Delete all labels from repository

--- a/labeler.js
+++ b/labeler.js
@@ -13,7 +13,6 @@ const helper = require('./lib/helper')
 
 // Require: Files
 const pkg = require('./package.json')
-const axios = require('./lib/axios')
 
 // Variables
 const helpText = `
@@ -179,8 +178,8 @@ async function main() {
     // This will delete and/or upload all labels to every repository under the owner organization in GHE
     // Currently only handles GHE instances, but could probably be adapted for a GitHub user
     if (cli.flags.bulkUpdate) {
-        let exit = false;
-        let repos = await helper.getRepositories(token, owner, host, cli)
+        let exit = false
+        const repos = await helper.getRepositories(token, owner, host)
         for (let i=0; i<repos.length; i++) {
             if (i === repos.length - 1) exit = true
             if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repos[i], cli, exit) // Delete all labels from repository

--- a/labeler.js
+++ b/labeler.js
@@ -83,8 +83,8 @@ EXAMPLES
     Using GitHub Enterprise hosts:
         labeler -dur Labeler -H github.yourhost.com
     
-    Update all labels from a GHE organization:
-        labeler -b -H github.yourhost.com
+    Delete and upload all labels from a GHE organization:
+        labeler -dub -H github.yourhost.com
 `;
 
 // Meow CLI

--- a/labeler.js
+++ b/labeler.js
@@ -169,9 +169,10 @@ async function main() {
 
     // Check if flags were called correctly
     helper.checkFlags(cli)
-
-    // Check for -d or -u
-    if (cli.flags.deleteAllLabels || cli.flags.uploadLabels) helper.echoOwnerRepository(owner, repository)
+    
+    // Check for flags
+    if (cli.flags.bulkUpdate) helper.echoOwnerRepository(owner, 'Various')
+    else if (cli.flags.deleteAllLabels || cli.flags.uploadLabels) helper.echoOwnerRepository(owner, repository)
 
     // Run functions according to flags
     if (cli.flags.path) helper.labelsPath() // Return labels.json path

--- a/labeler.js
+++ b/labeler.js
@@ -82,6 +82,9 @@ EXAMPLES
 
     Using GitHub Enterprise hosts:
         labeler -dur Labeler -H github.yourhost.com
+    
+    Update all labels from a GHE organization:
+        labeler -b -H github.yourhost.com
 `;
 
 // Meow CLI
@@ -179,9 +182,9 @@ async function main() {
     // Currently only handles GHE instances, but could probably be adapted for a GitHub user
     if (cli.flags.bulkUpdate) {
         const repos = await helper.getRepositories(token, owner, host)
-        for (let i=0; i<repos.length; i++) {
-            if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repos[i], cli, false) // Delete all labels from repository
-            if (cli.flags.uploadLabels) await helper.uploadLabels(token, owner, host, repos[i], cli, false) // Upload custom labels to repository
+        for (repo of repos) {
+            if (cli.flags.deleteAllLabels) await helper.deleteAllLabels(token, owner, host, repo, cli, false) // Delete all labels from repository
+            if (cli.flags.uploadLabels) await helper.uploadLabels(token, owner, host, repo, cli, false) // Upload custom labels to repository
         }
         echo.success('Finished!', true)
     }

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -101,7 +101,7 @@ function deleteLabel(exit, token, label) {
         })
 }
 
-// Get headers from request to list all repos for an organization
+// Gets headers from request to list all repos for an organization
 function headRepoList(exit, token, owner, host, perPage) {
     // Variables
     let url = 'https://' + host + '/api/v3/orgs/' + owner + '/repos?sort=full_name&per_page=' + perPage
@@ -115,20 +115,20 @@ function headRepoList(exit, token, owner, host, perPage) {
             }
         })
         .catch(function (err) {
-            // If response.status is 404
-            if (err.response.status == 404) {
-                echo.error('404: Not found.')
-                echo.error('URL seems to be faulty: ' + url)
-                echo.error('Please check your arguments and try again.', true)
+            if (err.response) {
+                if (err.response.status == 404) {
+                    echo.error('404: Not found.')
+                    echo.error('URL seems to be faulty: ' + url)
+                    echo.error('Please check your arguments and try again.', true)
+                }
             } else {
                 echo.error('An unexpected error occurred.')
                 echo.error(err.message, exit)
             }
         })
-
-    // console.log(parse_link_header(response.headers.link))
 }
 
+// Gets the "pageNum" page of the repos list with up to "perPage" records
 function getReopsByPage(exit, token, owner, host, pageNum, perPage) {
     // Variables
     let url = 'https://' + host + '/api/v3/orgs/' + owner + '/repos?sort=full_name&page=' + pageNum + '&per_page=' + perPage
@@ -142,41 +142,40 @@ function getReopsByPage(exit, token, owner, host, pageNum, perPage) {
             }
         })
         .catch(function (err) {
-            // If response.status is 404
-            if (err.response.status == 404) {
-                echo.error('404: Not found.')
-                echo.error('URL seems to be faulty: ' + url)
-                echo.error('Please check your arguments and try again.', true)
+            if (err.response) {
+                if (err.response.status == 404) {
+                    echo.error('404: Not found.')
+                    echo.error('URL seems to be faulty: ' + url)
+                    echo.error('Please check your arguments and try again.', true)
+                }
             } else {
                 echo.error('An unexpected error occurred.')
                 echo.error(err.message, exit)
             }
         })
-
-    // console.log(parse_link_header(response.headers.link))
 }
 
+// Returns an object with props "name: url", by parsing the link response header
+// Currently unused, but leaving in case it is decided to traverse the API pages using the relational links instead of the page count
 function parse_link_header(header) {
-    if (header.length === 0) {
-        throw new Error("input must not be of zero length");
-    }
+    if (header.length === 0) echo.error('header input must not be of zero length', true)
 
     // Split parts by comma
-    var parts = header.split(',');
-    var links = {};
+    let parts = header.split(',');
+    let links = {};
+
     // Parse each part into a named link
-    for(var i=0; i<parts.length; i++) {
-        var section = parts[i].split(';');
+    for(let i=0; i<parts.length; i++) {
+        let section = parts[i].split(';');
         if (section.length !== 2) {
-            throw new Error("section could not be split on ';'");
+            echo.error('section could not be split on ";"', true)
         }
-        var url = section[0].replace(/<(.*)>/, '$1').trim();
-        var name = section[1].replace(/rel="(.*)"/, '$1').trim();
+        let url = section[0].replace(/<(.*)>/, '$1').trim();
+        let name = section[1].replace(/rel="(.*)"/, '$1').trim();
         links[name] = url;
     }
     return links;
 }
-
 
 
 // Exports

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -132,7 +132,7 @@ function headRepoList(exit, token, owner, host, perPage) {
 }
 
 // Gets the "pageNum" page of the repos list with up to "perPage" records
-function getReopsByPage(exit, token, owner, host, pageNum, perPage) {
+function getReposByPage(exit, token, owner, host, pageNum, perPage) {
     // Variables
     let url = 'https://' + host + '/api/v3/orgs/' + owner + '/repos?sort=full_name&page=' + pageNum + '&per_page=' + perPage
 

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -64,14 +64,16 @@ function saveLabel(exit, token, owner, host, repository, label) {
             echo.upload(label.name)
         })
         .catch(function (err) {
-            if (err.response.status == 404) {
-                // If response.status is 404
-                echo.error('404: Not found.')
-                echo.error('URL seems to be faulty: ' + url)
-                echo.error('Please check your arguments and try again.', true)
-            } else if (err.response.status == 422 && err.response.data.errors[0].code == 'already_exists') {
-                // If already_exists
-                echo.skip(label.name)
+            if (err.response) {
+                if (err.response.status == 404) {
+                    // If response.status is 404
+                    echo.error('404: Not found.')
+                    echo.error('URL seems to be faulty: ' + url)
+                    echo.error('Please check your arguments and try again.', true)
+                } else if (err.response.status == 422 && err.response.data.errors[0].code == 'already_exists') {
+                    // If already_exists
+                    echo.skip(label.name)
+                }
             } else {
                 echo.error('An unexpected error occurred.')
                 echo.error('Label: ' + JSON.stringify(label))
@@ -99,9 +101,89 @@ function deleteLabel(exit, token, label) {
         })
 }
 
+// Get headers from request to list all repos for an organization
+function headRepoList(exit, token, owner, host, perPage) {
+    // Variables
+    let url = 'https://' + host + '/api/v3/orgs/' + owner + '/repos?sort=full_name&per_page=' + perPage
+
+    // HEAD request
+    return axios    
+        .head(url, {
+            headers: {
+                Authorization: 'Bearer ' + token,
+                accept: 'application/vnd.github.v3+json'
+            }
+        })
+        .catch(function (err) {
+            // If response.status is 404
+            if (err.response.status == 404) {
+                echo.error('404: Not found.')
+                echo.error('URL seems to be faulty: ' + url)
+                echo.error('Please check your arguments and try again.', true)
+            } else {
+                echo.error('An unexpected error occurred.')
+                echo.error(err.message, exit)
+            }
+        })
+
+    // console.log(parse_link_header(response.headers.link))
+}
+
+function getReopsByPage(exit, token, owner, host, pageNum, perPage) {
+    // Variables
+    let url = 'https://' + host + '/api/v3/orgs/' + owner + '/repos?sort=full_name&page=' + pageNum + '&per_page=' + perPage
+
+    // Get request
+    return axios    
+        .get(url, {
+            headers: {
+                Authorization: 'Bearer ' + token,
+                accept: 'application/vnd.github.v3+json'
+            }
+        })
+        .catch(function (err) {
+            // If response.status is 404
+            if (err.response.status == 404) {
+                echo.error('404: Not found.')
+                echo.error('URL seems to be faulty: ' + url)
+                echo.error('Please check your arguments and try again.', true)
+            } else {
+                echo.error('An unexpected error occurred.')
+                echo.error(err.message, exit)
+            }
+        })
+
+    // console.log(parse_link_header(response.headers.link))
+}
+
+function parse_link_header(header) {
+    if (header.length === 0) {
+        throw new Error("input must not be of zero length");
+    }
+
+    // Split parts by comma
+    var parts = header.split(',');
+    var links = {};
+    // Parse each part into a named link
+    for(var i=0; i<parts.length; i++) {
+        var section = parts[i].split(';');
+        if (section.length !== 2) {
+            throw new Error("section could not be split on ';'");
+        }
+        var url = section[0].replace(/<(.*)>/, '$1').trim();
+        var name = section[1].replace(/rel="(.*)"/, '$1').trim();
+        links[name] = url;
+    }
+    return links;
+}
+
+
+
 // Exports
 module.exports = {
     getLabels: getLabels,
     saveLabel: saveLabel,
-    deleteLabel: deleteLabel
+    deleteLabel: deleteLabel,
+    headRepoList: headRepoList,
+    getReopsByPage: getReopsByPage
 }

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -158,31 +158,6 @@ function getReposByPage(exit, token, owner, host, pageNum, perPage) {
         })
 }
 
-// Returns an object with props "name: url", by parsing the link response header
-// Currently unused, but leaving in case it is decided to traverse the API pages using the relational links instead of the page count
-function parse_link_header(header) {
-    if (!header || header.length === 0) {
-        echo.error('header input must not be null or of zero length', true)
-    }
-
-    // Split parts by comma
-    let parts = header.split(',')
-    let links = {}
-
-    // Parse each part into a named link
-    for(let i=0; i<parts.length; i++) {
-        let section = parts[i].split(';')
-        if (section.length !== 2) {
-            echo.error('section could not be split on ";"', true)
-        }
-        
-        let url = section[0].replace(/<(.*)>/, '$1').trim()
-        let name = section[1].replace(/rel="(.*)"/, '$1').trim()
-        links[name] = url
-    }
-    return links
-}
-
 
 // Exports
 module.exports = {
@@ -190,5 +165,5 @@ module.exports = {
     saveLabel: saveLabel,
     deleteLabel: deleteLabel,
     headRepoList: headRepoList,
-    getReopsByPage: getReopsByPage
+    getReposByPage: getReposByPage
 }

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -63,7 +63,6 @@ function saveLabel(exit, token, owner, host, repository, label) {
             }
         })
         .then(function () {
-            // echo.info(chalk.italic('Uploaded ') + label.name)
             echo.upload(label.name)
         })
         .catch(function (err) {
@@ -110,7 +109,7 @@ function headRepoList(exit, token, owner, host, perPage) {
     let url = 'https://' + host + '/api/v3/orgs/' + owner + '/repos?sort=full_name&per_page=' + perPage
 
     // HEAD request
-    return axios    
+    return axios
         .head(url, {
             headers: {
                 Authorization: 'Bearer ' + token,
@@ -137,7 +136,7 @@ function getReposByPage(exit, token, owner, host, pageNum, perPage) {
     let url = 'https://' + host + '/api/v3/orgs/' + owner + '/repos?sort=full_name&page=' + pageNum + '&per_page=' + perPage
 
     // Get request
-    return axios    
+    return axios
         .get(url, {
             headers: {
                 Authorization: 'Bearer ' + token,
@@ -157,7 +156,6 @@ function getReposByPage(exit, token, owner, host, pageNum, perPage) {
             }
         })
 }
-
 
 // Exports
 module.exports = {

--- a/lib/axios.js
+++ b/lib/axios.js
@@ -27,11 +27,14 @@ function getLabels(exit, token, owner, host, repository) {
         })
         .catch(function (err) {
             // If response.status is 404
-            if (err.response.status == 404) {
-                echo.error('404: Not found.')
-                echo.error('URL seems to be faulty: ' + url)
-                echo.error('Please check your arguments and try again.', true)
-            } else {
+            if (err.response) {
+                if (err.response.status == 404) {
+                    echo.error('404: Not found.')
+                    echo.error('URL seems to be faulty: ' + url)
+                    echo.error('Please check your arguments and try again.', true)
+                }
+            }
+            else {
                 echo.error('An unexpected error occurred.')
                 echo.error(err.message, exit)
             }
@@ -158,23 +161,26 @@ function getReopsByPage(exit, token, owner, host, pageNum, perPage) {
 // Returns an object with props "name: url", by parsing the link response header
 // Currently unused, but leaving in case it is decided to traverse the API pages using the relational links instead of the page count
 function parse_link_header(header) {
-    if (header.length === 0) echo.error('header input must not be of zero length', true)
+    if (!header || header.length === 0) {
+        echo.error('header input must not be null or of zero length', true)
+    }
 
     // Split parts by comma
-    let parts = header.split(',');
-    let links = {};
+    let parts = header.split(',')
+    let links = {}
 
     // Parse each part into a named link
     for(let i=0; i<parts.length; i++) {
-        let section = parts[i].split(';');
+        let section = parts[i].split(';')
         if (section.length !== 2) {
             echo.error('section could not be split on ";"', true)
         }
-        let url = section[0].replace(/<(.*)>/, '$1').trim();
-        let name = section[1].replace(/rel="(.*)"/, '$1').trim();
-        links[name] = url;
+        
+        let url = section[0].replace(/<(.*)>/, '$1').trim()
+        let name = section[1].replace(/rel="(.*)"/, '$1').trim()
+        links[name] = url
     }
-    return links;
+    return links
 }
 
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -205,7 +205,7 @@ async function getRepositories(token, owner, host) {
 // Push every repo into repos array
     for (let i=1; i<=pageCount; i++) {
         const res = await axios.getReposByPage(true, token, owner, host, i, perPage)
-        res.data.forEach(repo => {
+        res.data.forEach(function (repo) {
             // Get the url for each repo object and extract just the name at the end of the url
             repos.push(repo.html_url.substring(repo.html_url.lastIndexOf('/') + 1))
         })
@@ -216,24 +216,32 @@ async function getRepositories(token, owner, host) {
 
 // Gets the total number of pages in the list of repositories by parsing the "last" rel of the "link" response header
 // GitHubApi has a per_page limit of 100, default 30
+//
+// To instead return a 'links' object with props 'name: url' in order to traverse the API pages using the relational links instead of the page count
+// Uncomment the code below, comment the last if statement and last error log
 function getPageCountFromLinkHeader(header) {
-    if (!header || header.length === 0) echo.error('header input must not be null or of zero length', true)
+    if (!header || header.length === 0) echo.error('Header input must not be null or of zero length', true)
 
     // Split parts by comma
-    var parts = header.split(',')
+    let parts = header.split(',')
+    // let links = {}
 
     // Parse each part into a named link
-    for(var i=0; i<parts.length; i++) {
-        let section = parts[i].split(';')
-        if (section.length !== 2) echo.error('section could not be split on ";"', true)
+    for(i of parts) {
+        let section = i.split(';')
+        if (section.length !== 2) echo.error('Section could not be split on ";"', true)
 
-        var url = section[0].replace(/<(.*)>/, '$1').trim()
-        var name = section[1].replace(/rel="(.*)"/, '$1').trim()
+        const url = section[0].replace(/<(.*)>/, '$1').trim()
+        const name = section[1].replace(/rel="(.*)"/, '$1').trim()
         if (name === 'last') return url.match(/.*&page=(\d+).*/)[1]
+
+        // links[name] = url
     }
     
     // Log error and exit if the last page link cannot be found
     echo.error('Repository page count could not be found for given GHE org', true)
+    
+    // return links
 }
 
 // Opens the interactive config CLI

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -66,9 +66,10 @@ function checkFlags(cli) {
 
     // Check for usage of flags that shouldn't be used together
     // If (((Flags) && (Flags)) || (cli.flags.config && cli.flags.newLabel) || (cli.flags.emptyLabelsFile && (Flags)))
-    if (((cli.flags.repository || cli.flags.token || cli.flags.owner || cli.flags.host || cli.flags.uploadLabels || cli.flags.deleteAllLabels) && (cli.flags.newLabel || cli.flags.config))
+    if (((cli.flags.repository || cli.flags.token || cli.flags.owner || cli.flags.host || cli.flags.bulkUpdate || cli.flags.uploadLabels || cli.flags.deleteAllLabels) && (cli.flags.newLabel || cli.flags.config))
+        || (cli.flags.bulkUpdate && cli.flags.host == pkg.labeler.defaultHost)
         || (cli.flags.config && cli.flags.newLabel)
-        || (cli.flags.emptyLabelsFile && (cli.flags.repository || cli.flags.token || cli.flags.owner || cli.flags.host || cli.flags.uploadLabels || cli.flags.deleteAllLabels || cli.flags.config || cli.flags.resetLabelsFile))) {
+        || (cli.flags.emptyLabelsFile && (cli.flags.repository || cli.flags.token || cli.flags.owner || cli.flags.host || cli.flags.bulkUpdate || cli.flags.uploadLabels || cli.flags.deleteAllLabels || cli.flags.config || cli.flags.resetLabelsFile))) {
         echo.error('Wrong usage.')
         echo.tip('Use -h for help.', true)
     }
@@ -110,7 +111,7 @@ async function emptyLabelsFile(cli) {
 }
 
 // Upload all labels from labels.json
-async function uploadLabels(token, owner, host, repository, cli) {
+async function uploadLabels(token, owner, host, repository, cli, exit) {
     // Check required Flags
     checkRequiredFlags(token, owner, repository)
 
@@ -119,8 +120,10 @@ async function uploadLabels(token, owner, host, repository, cli) {
 
     // Ask if the user is sure
     if (!cli.flags.force) {
-        const answer = await inquirer.confirmUploadLabels()
+        const answer = await inquirer.confirmUploadLabels(repository)
         if (!answer.uploadLabels) {
+            if (cli.flags.bulkUpdate) return
+
             console.log()
             echo.abort('Upload labels to ' + repository + '.', true)
         }
@@ -138,18 +141,20 @@ async function uploadLabels(token, owner, host, repository, cli) {
 
     // Done
     echo.success('Done!\n')
-    echo.success('Finished!', true)
+    if (exit) echo.success('Finished!', exit)
 }
 
 // Deletes all labels from a repository
-async function deleteAllLabels(token, owner, host, repository, cli) {
+async function deleteAllLabels(token, owner, host, repository, cli, exit) {
     // Check required Flags
     checkRequiredFlags(token, owner, repository)
 
     // Ask if the user is sure
     if (!cli.flags.force) {
-        const answer = await inquirer.confirmDeleteAllLabels()
+        const answer = await inquirer.confirmDeleteAllLabels(repository)
         if (!answer.deleteAllLabels) {
+            if (cli.flags.bulkUpdate) return
+
             console.log()
             echo.abort('Delete labels from ' + repository + '.', true)
         }
@@ -172,8 +177,52 @@ async function deleteAllLabels(token, owner, host, repository, cli) {
     if (cli.flags.uploadLabels) echo.success('Done!\n')
     else {
         console.log()
-        echo.success('Finished!', true)
+        if (exit) echo.success('Finished!', exit)
     }
+}
+
+async function getRepositories(token, owner, host, cli) {
+    // Variables
+    let repos = []
+    const perPage = 100
+    
+    // Check required Flags
+    checkRequiredFlags(token, owner, "sample")
+
+    echo.info(chalk.bold('Fetching list of repository names in organization ' + owner + '...'))
+
+    // Get headers for a request to list all repositories for the given org
+    const response = await axios.headRepoList(true, token, owner, host, perPage)
+    let pageCount = getPageCountFromLinkHeader(response.headers.link)
+
+    for (let i=1; i<=pageCount; i++) {
+        let res = await axios.getReopsByPage(true, token, owner, host, i, perPage)
+        res.data.forEach(repo => {
+            repos.push(repo.html_url.substring(repo.html_url.lastIndexOf('/') + 1))
+        });
+    }
+
+    return repos
+}
+
+function getPageCountFromLinkHeader(header) {
+    if (header.length === 0) {
+        throw new Error("input must not be of zero length");
+    }
+    // Split parts by comma
+    var parts = header.split(',');
+    // Parse each part into a named link
+    for(var i=0; i<parts.length; i++) {
+        var section = parts[i].split(';');
+        if (section.length !== 2) {
+            throw new Error("section could not be split on ';'");
+        }
+        var url = section[0].replace(/<(.*)>/, '$1').trim();
+        var name = section[1].replace(/rel="(.*)"/, '$1').trim();
+        if (name === 'last') return url.match(/.*&page=(\d+).*/)[1]
+    }
+    
+    echo.error('Repository page count could not be found for given GHE org', true)
 }
 
 // Opens the interactive config CLI
@@ -257,6 +306,7 @@ module.exports = {
     emptyLabelsFile: emptyLabelsFile,
     deleteAllLabels: deleteAllLabels,
     uploadLabels: uploadLabels,
+    getRepositories: getRepositories,
     cliConfig: cliConfig,
     cliNewLabel: cliNewLabel
 }

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -175,18 +175,19 @@ async function deleteAllLabels(token, owner, host, repository, cli, exit) {
 
     // Done
     if (cli.flags.uploadLabels) echo.success('Done!\n')
-    else {
+    else if (exit) {
         console.log()
-        if (exit) echo.success('Finished!', exit)
+        echo.success('Finished!', exit)
     }
 }
 
+// Gets array of repository names in "owner" organization
 async function getRepositories(token, owner, host, cli) {
     // Variables
     let repos = []
     const perPage = 100
     
-    // Check required Flags
+    // Check required Flags (repository not needed here but need to send so check won't fail)
     checkRequiredFlags(token, owner, "sample")
 
     echo.info(chalk.bold('Fetching list of repository names in organization ' + owner + '...'))
@@ -198,6 +199,7 @@ async function getRepositories(token, owner, host, cli) {
     for (let i=1; i<=pageCount; i++) {
         let res = await axios.getReopsByPage(true, token, owner, host, i, perPage)
         res.data.forEach(repo => {
+            // Get the url for each repo object and extract just the name at the end of the url
             repos.push(repo.html_url.substring(repo.html_url.lastIndexOf('/') + 1))
         });
     }
@@ -205,6 +207,8 @@ async function getRepositories(token, owner, host, cli) {
     return repos
 }
 
+// Gets the total number of pages in the list of repositories by parsing the "last" rel of the "link" response header
+// GitHubApi has a per_page limit of 100, default 30
 function getPageCountFromLinkHeader(header) {
     if (header.length === 0) {
         throw new Error("input must not be of zero length");

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -182,7 +182,7 @@ async function deleteAllLabels(token, owner, host, repository, cli, exit) {
 }
 
 // Gets array of repository names in "owner" organization
-async function getRepositories(token, owner, host, cli) {
+async function getRepositories(token, owner, host) {
     // Variables
     let repos = []
     let pageCount = 0
@@ -192,22 +192,23 @@ async function getRepositories(token, owner, host, cli) {
     checkRequiredFlags(token, owner, "sample")
 
     // Get headers for a request to list all repositories for the given org
-    let response = await axios.headRepoList(true, token, owner, host, 1)
+    const response = await axios.headRepoList(true, token, owner, host, 1)
     if (response.status != 200 || !response.headers.link) echo.error('Unexpected status or response on HEAD request for GHE repository list.', true)
 
     // By passing in 1 as the per_page value, the "last" page link will have a page number equal to the number of repos
     // To compute the actual number of necessary requests, divide the number of repos by the requested per_page limit (max 100)
-    let numberOfRepos = getPageCountFromLinkHeader(response.headers.link)
+    const numberOfRepos = getPageCountFromLinkHeader(response.headers.link)
     pageCount = Math.ceil(numberOfRepos / perPage)
 
     echo.info(chalk.bold('Fetching list of ' + numberOfRepos + ' repository name(s) across ' + pageCount + ' page(s), in organization ' + owner + '...'))
 
+// Push every repo into repos array
     for (let i=1; i<=pageCount; i++) {
-        let res = await axios.getReopsByPage(true, token, owner, host, i, perPage)
+        const res = await axios.getReposByPage(true, token, owner, host, i, perPage)
         res.data.forEach(repo => {
             // Get the url for each repo object and extract just the name at the end of the url
             repos.push(repo.html_url.substring(repo.html_url.lastIndexOf('/') + 1))
-        });
+        })
     }
 
     return repos
@@ -216,19 +217,15 @@ async function getRepositories(token, owner, host, cli) {
 // Gets the total number of pages in the list of repositories by parsing the "last" rel of the "link" response header
 // GitHubApi has a per_page limit of 100, default 30
 function getPageCountFromLinkHeader(header) {
-    if (!header || header.length === 0) {
-        echo.error('header input must not be null or of zero length', true)
-    }
+    if (!header || header.length === 0) echo.error('header input must not be null or of zero length', true)
 
     // Split parts by comma
     var parts = header.split(',')
 
     // Parse each part into a named link
     for(var i=0; i<parts.length; i++) {
-        var section = parts[i].split(';')
-        if (section.length !== 2) {
-            echo.error('section could not be split on ";"', true)
-        }
+        let section = parts[i].split(';')
+        if (section.length !== 2) echo.error('section could not be split on ";"', true)
 
         var url = section[0].replace(/<(.*)>/, '$1').trim()
         var name = section[1].replace(/rel="(.*)"/, '$1').trim()

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -185,16 +185,22 @@ async function deleteAllLabels(token, owner, host, repository, cli, exit) {
 async function getRepositories(token, owner, host, cli) {
     // Variables
     let repos = []
+    let pageCount = 0
     const perPage = 100
     
     // Check required Flags (repository not needed here but need to send so check won't fail)
     checkRequiredFlags(token, owner, "sample")
 
-    echo.info(chalk.bold('Fetching list of repository names in organization ' + owner + '...'))
-
     // Get headers for a request to list all repositories for the given org
-    const response = await axios.headRepoList(true, token, owner, host, perPage)
-    let pageCount = getPageCountFromLinkHeader(response.headers.link)
+    let response = await axios.headRepoList(true, token, owner, host, 1)
+    if (response.status != 200 || !response.headers.link) echo.error('Unexpected status or response on HEAD request for GHE repository list.', true)
+
+    // By passing in 1 as the per_page value, the "last" page link will have a page number equal to the number of repos
+    // To compute the actual number of necessary requests, divide the number of repos by the requested per_page limit (max 100)
+    let numberOfRepos = getPageCountFromLinkHeader(response.headers.link)
+    pageCount = Math.ceil(numberOfRepos / perPage)
+
+    echo.info(chalk.bold('Fetching list of ' + numberOfRepos + ' repository name(s) across ' + pageCount + ' page(s), in organization ' + owner + '...'))
 
     for (let i=1; i<=pageCount; i++) {
         let res = await axios.getReopsByPage(true, token, owner, host, i, perPage)
@@ -210,22 +216,26 @@ async function getRepositories(token, owner, host, cli) {
 // Gets the total number of pages in the list of repositories by parsing the "last" rel of the "link" response header
 // GitHubApi has a per_page limit of 100, default 30
 function getPageCountFromLinkHeader(header) {
-    if (header.length === 0) {
-        throw new Error("input must not be of zero length");
+    if (!header || header.length === 0) {
+        echo.error('header input must not be null or of zero length', true)
     }
+
     // Split parts by comma
-    var parts = header.split(',');
+    var parts = header.split(',')
+
     // Parse each part into a named link
     for(var i=0; i<parts.length; i++) {
-        var section = parts[i].split(';');
+        var section = parts[i].split(';')
         if (section.length !== 2) {
-            throw new Error("section could not be split on ';'");
+            echo.error('section could not be split on ";"', true)
         }
-        var url = section[0].replace(/<(.*)>/, '$1').trim();
-        var name = section[1].replace(/rel="(.*)"/, '$1').trim();
+
+        var url = section[0].replace(/<(.*)>/, '$1').trim()
+        var name = section[1].replace(/rel="(.*)"/, '$1').trim()
         if (name === 'last') return url.match(/.*&page=(\d+).*/)[1]
     }
     
+    // Log error and exit if the last page link cannot be found
     echo.error('Repository page count could not be found for given GHE org', true)
 }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -187,7 +187,7 @@ async function getRepositories(token, owner, host) {
     let repos = []
     let pageCount = 0
     const perPage = 100
-    
+
     // Check required Flags (repository not needed here but need to send so check won't fail)
     checkRequiredFlags(token, owner, "sample")
 
@@ -202,34 +202,32 @@ async function getRepositories(token, owner, host) {
 
     echo.info(chalk.bold('Fetching list of ' + numberOfRepos + ' repository name(s) across ' + pageCount + ' page(s), in organization ' + owner + '...'))
 
-// Push every repo into repos array
-    for (let i=1; i<=pageCount; i++) {
+    // Push every repo into repos array
+    for (let i = 1; i <= pageCount; i++) {
         const res = await axios.getReposByPage(true, token, owner, host, i, perPage)
         res.data.forEach(function (repo) {
             // Get the url for each repo object and extract just the name at the end of the url
             repos.push(repo.html_url.substring(repo.html_url.lastIndexOf('/') + 1))
         })
     }
-
     return repos
 }
 
 // Gets the total number of pages in the list of repositories by parsing the "last" rel of the "link" response header
 // GitHubApi has a per_page limit of 100, default 30
-//
 // To instead return a 'links' object with props 'name: url' in order to traverse the API pages using the relational links instead of the page count
 // Uncomment the code below, comment the last if statement and last error log
 function getPageCountFromLinkHeader(header) {
-    if (!header || header.length === 0) echo.error('Header input must not be null or of zero length', true)
+    if (!header || header.length === 0) echo.error('Header input must not be null or of zero length.', true)
 
     // Split parts by comma
     let parts = header.split(',')
     // let links = {}
 
     // Parse each part into a named link
-    for(i of parts) {
+    for (i of parts) {
         let section = i.split(';')
-        if (section.length !== 2) echo.error('Section could not be split on ";"', true)
+        if (section.length !== 2) echo.error('Section could not be split on ";".', true)
 
         const url = section[0].replace(/<(.*)>/, '$1').trim()
         const name = section[1].replace(/rel="(.*)"/, '$1').trim()
@@ -237,10 +235,10 @@ function getPageCountFromLinkHeader(header) {
 
         // links[name] = url
     }
-    
+
     // Log error and exit if the last page link cannot be found
-    echo.error('Repository page count could not be found for given GHE org', true)
-    
+    echo.error('Repository page count could not be found for given GHE org.', true)
+
     // return links
 }
 

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -227,7 +227,7 @@ function getPageCountFromLinkHeader(header) {
     // Parse each part into a named link
     for (i of parts) {
         let section = i.split(';')
-        if (section.length !== 2) echo.error('Section could not be split on ";".', true)
+        if (section.length !== 2) echo.error('Section could not be properly split on ";".', true)
 
         const url = section[0].replace(/<(.*)>/, '$1').trim()
         const name = section[1].replace(/rel="(.*)"/, '$1').trim()

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -69,7 +69,8 @@ function checkFlags(cli) {
     if (((cli.flags.repository || cli.flags.token || cli.flags.owner || cli.flags.host || cli.flags.bulkUpdate || cli.flags.uploadLabels || cli.flags.deleteAllLabels) && (cli.flags.newLabel || cli.flags.config))
         || (cli.flags.bulkUpdate && cli.flags.host == pkg.labeler.defaultHost)
         || (cli.flags.config && cli.flags.newLabel)
-        || (cli.flags.emptyLabelsFile && (cli.flags.repository || cli.flags.token || cli.flags.owner || cli.flags.host || cli.flags.bulkUpdate || cli.flags.uploadLabels || cli.flags.deleteAllLabels || cli.flags.config || cli.flags.resetLabelsFile))) {
+        || (cli.flags.emptyLabelsFile && (cli.flags.repository || cli.flags.token || cli.flags.owner || cli.flags.host || cli.flags.bulkUpdate || cli.flags.uploadLabels || cli.flags.deleteAllLabels || cli.flags.config || cli.flags.resetLabelsFile))
+        || (cli.flags.bulkUpdate && cli.flags.repository)) {
         echo.error('Wrong usage.')
         echo.tip('Use -h for help.', true)
     }

--- a/lib/inquirer.js
+++ b/lib/inquirer.js
@@ -119,22 +119,6 @@ const confirmRepo = {
     default: false
 }
 
-// Confirm deletion of labels
-const confirmDeletionAllLabels = {
-    type: 'confirm',
-    name: 'deleteAllLabels',
-    message: 'Are you sure you want to delete ALL labels from the repository?',
-    default: false
-}
-
-// Confirm upload of labels
-const confirmLabelUpload = {
-    type: 'confirm',
-    name: 'uploadLabels',
-    message: 'Are you sure you want to upload all labels from labels.json to the repository?',
-    default: false
-}
-
 // Confirm emptying labels.json
 const confirmLabelsEmpty = {
     type: 'confirm',
@@ -153,10 +137,24 @@ const confirmLabelsReset = {
 
 /* --- Functions --- */
 // Confirm deletion of all labels
-function confirmDeleteAllLabels() { return inquirer.prompt(confirmDeletionAllLabels) }
+function confirmDeleteAllLabels(repository) {
+    return inquirer.prompt({
+        type: 'confirm',
+        name: 'deleteAllLabels',
+        message: 'Are you sure you want to delete ALL labels from the ' + repository + ' repository?',
+        default: false
+    })
+}
 
 // Confirm upload of all labels
-function confirmUploadLabels() { return inquirer.prompt(confirmLabelUpload) }
+function confirmUploadLabels(repository) {
+    return inquirer.prompt({
+        type: 'confirm',
+        name: 'uploadLabels',
+        message: 'Are you sure you want to upload all labels from labels.json to the ' + repository + ' repository?',
+        default: false
+    })
+}
 
 // Confirm deletion of all labels in labels.json
 function confirmEmptyLabels() { return inquirer.prompt(confirmLabelsEmpty) }


### PR DESCRIPTION
This PR adds support to upload labels to all repositories under a given GitHub Enterprise organization, without having to upload them one repo at a time.

I think I followed relatively closely to your code style, but let me know what you think and if you have any changes you would like to make. I tested this with my GHE instance and it works very well, but if you could test it with some regular GitHub repos to ensure I didn't break anything, that would be great!